### PR TITLE
Make compatible with Rails 3.2.22

### DIFF
--- a/lib/preload_counts/ar.rb
+++ b/lib/preload_counts/ar.rb
@@ -28,7 +28,7 @@ module PreloadCounts
         singleton.send :define_method, name do
           sql = ["#{table_name}.*"] + scopes_to_select(association, scopes)
           sql = sql.join(', ')
-          all.select(sql)
+          scoped.select(sql)
         end
 
         scopes.each do |scope|
@@ -61,9 +61,12 @@ module PreloadCounts
         conditions << condition
       end
 
-      r_scope = self.reflections.with_indifferent_access[association].scope
-      if r_scope
-        conditions += self.instance_eval(&r_scope).where_values
+      reflection = self.reflections.with_indifferent_access[association]
+      if reflection.respond_to?(:scope)
+        r_scope = reflection.scope
+        if r_scope
+          conditions += self.instance_eval(&r_scope).where_values
+        end
       end
 
       sql = <<-SQL


### PR DESCRIPTION
- use scoped instead of all. because all is not lazy in rails 3.2
- the reflection may not have the method scope. check that.
